### PR TITLE
Recipe backend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,10 @@
         "semi": [
             "error",
             "always"
+        ],
+        "no-unused-vars": [
+            "warn",
+            { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }
         ]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "eslint": "^8.1.0",
         "jest": "^27.3.1",
         "jest-puppeteer": "^6.0.0",
+        "node-fetch": "^3.1.0",
         "puppeteer": "^11.0.0"
       }
     },
@@ -1827,6 +1828,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -2413,6 +2423,28 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
+      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2561,6 +2593,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-constants": {
@@ -4160,37 +4204,21 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
+      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
       "dev": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.2",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -4546,6 +4574,40 @@
       },
       "engines": {
         "node": ">=10.18.1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/node-fetch": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/puppeteer/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/puppeteer/node_modules/ws": {
@@ -5298,6 +5360,15 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6919,6 +6990,12 @@
         "fs-exists-sync": "^0.1.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "dev": true
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -7360,6 +7437,15 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
+      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
+      "dev": true,
+      "requires": {
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7464,6 +7550,15 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fs-constants": {
@@ -8695,36 +8790,14 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
+      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
       "dev": true,
       "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.2",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-int64": {
@@ -8999,6 +9072,37 @@
         "ws": "8.2.3"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+          "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
         "ws": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
@@ -9578,6 +9682,12 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint": "^8.1.0",
     "jest": "^27.3.1",
     "jest-puppeteer": "^6.0.0",
+    "node-fetch": "^3.1.0",
     "puppeteer": "^11.0.0"
   },
   "jest": {

--- a/source/assets/scripts/api.js
+++ b/source/assets/scripts/api.js
@@ -5,7 +5,7 @@ import { recipe_data, keep_fields } from './recipe-data.js';
 /**
  * search a recipe by its name and return a promise of list of raw json
  * @param {string} name - name of the recipe
- * @param {[string]} intolerances - a list of intolerances. see below for details
+ * @param {Array<string>} intolerances - a list of intolerances. see below for details
  * @returns {Promise} - a list of unfiltered recipe, empty if non found
  */
 export async function search_recipe_raw(name, intolerances) {
@@ -22,7 +22,7 @@ export async function search_recipe_raw(name, intolerances) {
  * we then remap the field names by the rule fields_remap
  * if no recipe is found, it should return a promise of an empty list
  * @param {string} name - name of the recipe 
- * @param {[string]} intolerances - a list of intolerances. for a list of supported keywords, see 
+ * @param {Array<string>} intolerances - a list of intolerances. for a list of supported keywords, see 
  *  https://spoonacular.com/food-api/docs#:~:text=of%20supported%20diets.-,intolerances,-string
  *  Note that this functionality is pretty bad since if a recipe can be nut free without listing nuts as intolerance
  * @returns {Promise} - a list of filtered recipe

--- a/source/assets/scripts/api.js
+++ b/source/assets/scripts/api.js
@@ -1,57 +1,62 @@
-// Parameter:
-// Name: the name of the recipe
-// it will fetch the reicpe that contain the same word, If it can't find the recipe, then it will return undefiened
-// it will include analyze instruction and ingredient data 
-async function search_recipe_name(name){
-  let response=await fetch(`https://api.spoonacular.com/recipes/complexSearch?query=${name}&apiKey=486eca841c6a49b896486723439f9977&addRecipeInformation=true&fillIngredients=true`);
-  let data=await response.json();
-  let temp=data.results
-  return_list=new Array();
-  localStorage.clear();
-  for( let i=0; i<temp.length;i++){
-  let temp2={'Recipe hash':temp[i].id,
-              'Name':temp[i].title,
-              'imageType':temp[i].imageType,
-              'Thumbnail':temp[i].image,
-              'Author':temp[i].sourceName,
-              'Type':temp[i].dishTypes,
-              //'Difficulty':
-              'Ingredients':temp[i].extendedIngredients,//notice that the ingredient is not string, but a array of object, because it has a lot info
-              'Intolerances':temp[i].diets,//notice that the intolerence is not string, but a array
-              'Steps:':temp[i].analyzedInstructions[0].steps
-            };
-    set_localstore(temp2["Recipe hash"],temp2);
-    return_list.push(temp2)
-  }
-  return return_list;
+/** @module api */
+
+import { recipe_data, keep_fields } from './recipe-data.js'
+
+/**
+ * search a recipe by its name and return a promise of list of raw json
+ * @param {string} name - name of the recipe
+ * @returns {Promise} - a list of unfiltered recipe, empty if non found
+ */
+async function search_recipe_name_raw(name) {
+  const response = await fetch(`https://api.spoonacular.com/recipes/complexSearch?query=${name}&apiKey=486eca841c6a49b896486723439f9977&addRecipeInformation=true&fillIngredients=true`);
+  const data = await response.json();
+  if (data.results) return data.results;
+  else return [];  // an empty list
 }
+
+/**
+ * search a recipe by its name and keep only the parts we need according to the global variable keep_fields
+ * we then remap the field names by the rule fields_remap
+ * if no recipe is found, it should return a promise of an empty list
+ * @param {string} name - name of the recipe 
+ * @returns {Promise} - a list of filtered recipe
+ */
+export async function search_recipe_name(name) {
+  const raw_recipes = await search_recipe_name_raw(name);
+  // for each recipe, keep only ones in keep_fields and rename them to fields_remap
+  // const filtered_recipes = raw_recipes.map(
+  //   raw_recipe => keep_fields.reduce((a, b, i) => a[fields_remap[i]] = raw_recipe[b]));
+  return raw_recipes;
+}
+
+// search_recipe_name('pizza').then(console.log);
 
 // Parameter:
 // Name: the name of the recipe
 // heal: the filter we set, pass a comma-seperate string of what kind of filter we applied
 // it will fetch the reicpe that satify both parameters If it can't find the recipe, then it will return undefiened.
 // it will include analyze instruction and ingredient data 
-async function search_recipe_name_health(name,health)//health is an array
+export async function search_recipe_name_health(name,health)//health is an array
 {
   let response=await fetch(`https://api.spoonacular.com/recipes/complexSearch?query=${name}&intolerances=${health}&apiKey=486eca841c6a49b896486723439f9977&addRecipeInformation=true&fillIngredients=true`);
   let data=await response.json();
-  let temp=data.results
-  return_list=new Array();
+  let temp=data.results;
+  let return_list=new Array();
   localStorage.clear();
   for( let i=0; i<temp.length;i++){
-  let temp2={'Recipe hash':temp[i].id,
-              'Name':temp[i].title,
-              'imageType':temp[i].imageType,
-              'Thumbnail':temp[i].image,
-              'Author':temp[i].sourceName,
-              'Type':temp[i].dishTypes,
-              //'Difficulty':
-              'Ingredients':temp[i].extendedIngredients,//notice that the ingredient is not string, but a array of object, because it has a lot info
-              'Intolerances':temp[i].diets,//notice that the intolerence is not string, but a array
-              'Steps:':temp[i].analyzedInstructions[0].steps
-            };
-    set_localstore(temp2["Recipe hash"],temp2);
-    return_list.push(temp2)
+    let temp2={'Recipe hash':temp[i].id,
+      'Name':temp[i].title,
+      'imageType':temp[i].imageType,
+      'Thumbnail':temp[i].image,
+      'Author':temp[i].sourceName,
+      'Type':temp[i].dishTypes,
+      //'Difficulty':
+      'Ingredients':temp[i].extendedIngredients,//notice that the ingredient is not string, but a array of object, because it has a lot info
+      'Intolerances':temp[i].diets,//notice that the intolerence is not string, but a array
+      'Steps:':temp[i].analyzedInstructions[0].steps
+    };
+    set_localstore(temp2['Recipe hash'],temp2);
+    return_list.push(temp2);
   }
   return return_list;
 }
@@ -105,7 +110,7 @@ function add_favorite(id){
     if(fav.indexOf(id)==-1){
       fav.push(id);
       remove_localstore('favorite');
-      set_localstore('favorite',fav)
+      set_localstore('favorite',fav);
     }
     else{
       console.log('Add: Recipe already in the favorite list');
@@ -122,15 +127,15 @@ function remove_favorite(id){
     console.log('Favorite list is empty');
   }
   else{
-    let index=fav.indexOf(id)
+    let index=fav.indexOf(id);
     if(index==-1)
     {
       console.log('Remove: Recipe not in the favorite list');
     }
     else{
-     fav.splice(index,1);
-     remove_localstore('favorite');
-     set_localstore('favorite',fav)
+      fav.splice(index,1);
+      remove_localstore('favorite');
+      set_localstore('favorite',fav);
     }
   }
 }
@@ -149,7 +154,7 @@ function add_custom(id){
     if(added.indexOf(id)==-1){
       added.push(id);
       remove_localstore('custom');
-      set_localstore('custom',added)
+      set_localstore('custom',added);
     }
     else{
       console.log('Add: Recipe already in the custom list');
@@ -166,62 +171,16 @@ function remove_custom(id){
     console.log('Custom list is empty');
   }
   else{
-    let index=added.indexOf(id)
+    let index=added.indexOf(id);
     if(index==-1)
     {
       console.log('Remove: Recipe not in the cuntom list');
     }
     else{
-     added.splice(index,1);
-     remove_localstore('custom');
-     set_localstore('custom',added)
+      added.splice(index,1);
+      remove_localstore('custom');
+      set_localstore('custom',added);
     }
   }
 }
-
-
-
-
-//if recipe can't be founded, the value will be undefined
-// a few sample to show how to use it
-// some example and test below
-// search_recipe_name('chicken').then(value=>{
-//   let a = value;
-//   console.log('test')
-//   console.log(a)
-//   console.log(get_info_localstore(a[0]["Recipe hash"]))
-// });
-  
-
-// search_recipe_name_health('chicken','dairy-free').then(value=>{
-//   let a = value;
-//   console.log('test3');
-//   console.log(a);
-// });
-
-// localStorage.clear();
-// console.log('fav test')
-// add_favorite('1412414');
-// console.log(get_info_localstore('favorite'));
-// add_favorite('12421421515');
-// console.log(get_info_localstore('favorite'));
-// add_favorite('12421421515');
-// console.log(get_info_localstore('favorite'));
-// remove_favorite('afsafafaf')
-// console.log(get_info_localstore('favorite'));
-// remove_favorite('12421421515')
-// console.log(get_info_localstore('favorite'));
-
-// console.log('cus test')
-// add_custom('1412414');
-// console.log(get_info_localstore('custom'));
-// add_custom('12421421515');
-// console.log(get_info_localstore('custom'));
-// add_custom('12421421515');
-// console.log(get_info_localstore('custom'));
-// remove_custom('afsafafaf')
-// console.log(get_info_localstore('custom'));
-// remove_custom('12421421515')
-// console.log(get_info_localstore('custom'));
-
 

--- a/source/assets/scripts/foodie.js
+++ b/source/assets/scripts/foodie.js
@@ -60,7 +60,7 @@ function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -68,20 +68,20 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("#");
+    window.location.replace('#');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }

--- a/source/assets/scripts/index.js
+++ b/source/assets/scripts/index.js
@@ -20,7 +20,7 @@ function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -28,20 +28,20 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-add.html");
+    window.location.replace('recipe-add.html');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }

--- a/source/assets/scripts/onBoardingPage.js
+++ b/source/assets/scripts/onBoardingPage.js
@@ -8,9 +8,9 @@ async function init() {
 
 function begin() {
   const btn = document.querySelector('.save');
-//   const text = document.getElementById('begin-text');
+  //   const text = document.getElementById('begin-text');
 
   btn.addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }

--- a/source/assets/scripts/preference-setting.js
+++ b/source/assets/scripts/preference-setting.js
@@ -28,18 +28,18 @@ function saveOrSaved() {
 }
 
 function goBack(){
-    const btn = document.getElementById('dount');
+  const btn = document.getElementById('dount');
 
-    btn.addEventListener('click', () => {
-        window.location.replace("settings.html");
-    });
+  btn.addEventListener('click', () => {
+    window.location.replace('settings.html');
+  });
 }
 
 function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -47,20 +47,20 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("#");
+    window.location.replace('#');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }

--- a/source/assets/scripts/recipe-add.js
+++ b/source/assets/scripts/recipe-add.js
@@ -3,13 +3,13 @@
 window.addEventListener('DOMContentLoaded', init);
 
 async function init() {
-    addIngredient();
-    addInstruction();
+  addIngredient();
+  addInstruction();
 
-    goDashboard();
-    goSearch();
-    goAdd();
-    goSettings();
+  goDashboard();
+  goSearch();
+  goAdd();
+  goSettings();
 
 
 
@@ -19,7 +19,7 @@ function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -27,56 +27,56 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-add.html");
+    window.location.replace('recipe-add.html');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }
 
 function addIngredient() {
-    const btn = document.getElementById('ingredientButton');
-    const box = document.getElementById('ingredientOrderedList');
-    console.log('hi');
+  const btn = document.getElementById('ingredientButton');
+  const box = document.getElementById('ingredientOrderedList');
+  console.log('hi');
   
-    btn.addEventListener('click', () => {
-        console.log('inside');
-        let node = document.createElement("LI");  
-        let nodeInput = document.createElement("input");
-        let br = document.createElement('br');
-        nodeInput.type='text';
-        nodeInput.appendChild(br);
-        node.appendChild(nodeInput);
-        box.appendChild(node);
+  btn.addEventListener('click', () => {
+    console.log('inside');
+    let node = document.createElement('LI');  
+    let nodeInput = document.createElement('input');
+    let br = document.createElement('br');
+    nodeInput.type='text';
+    nodeInput.appendChild(br);
+    node.appendChild(nodeInput);
+    box.appendChild(node);
       
-    });
+  });
 }
 
 function addInstruction() {
-    const btn = document.getElementById('instructionButton');
-    const box = document.getElementById('instructionOrderedList');
-    console.log('hiiii');
+  const btn = document.getElementById('instructionButton');
+  const box = document.getElementById('instructionOrderedList');
+  console.log('hiiii');
   
-    btn.addEventListener('click', () => {
-        console.log('inside');
-        let node = document.createElement("LI");  
-        let nodeInput = document.createElement("input");
-        let br = document.createElement('br');
-        nodeInput.type='text';
-        nodeInput.appendChild(br);
-        node.appendChild(nodeInput);
-        box.appendChild(node);
+  btn.addEventListener('click', () => {
+    console.log('inside');
+    let node = document.createElement('LI');  
+    let nodeInput = document.createElement('input');
+    let br = document.createElement('br');
+    nodeInput.type='text';
+    nodeInput.appendChild(br);
+    node.appendChild(nodeInput);
+    box.appendChild(node);
       
-    });
+  });
 }

--- a/source/assets/scripts/recipe-data.js
+++ b/source/assets/scripts/recipe-data.js
@@ -1,0 +1,39 @@
+/** @module recipe-data */
+
+// format of the recipe data object
+/** @global */
+export const recipe_data = {
+  'hash': 'a unique identifier, also the key in localstore',
+  'name': 'name of recipe',
+  'thumbnail': 'image url',
+  'author': 'name of creator',
+  'dishTypes': [],  // array of string. breakfast/lunch/etc.
+  'ingredients': [],  // array of Spoonacular ingredient objects
+  'intolerances': [],  // array of intolerances
+  'steps': [],  // array of Spoonacular step objects
+  'cuisines': [],  // 'array of string. American/Idian/etc.'
+  'pricePerServing': 0,
+  'readyInMinutes': 0,
+  'servings': 0,
+  'vegan': true,
+  'vegetarian': true
+}
+
+// fields we want to keep from the raw json response of Spoonacular and what they remap to
+/** @global */
+export const keep_fields = {
+  'id': 'hash',
+  'title': 'name',
+  'image': 'thumbnail',
+  'sourceName': 'author',
+  'dishTypes': 'dishTypes',
+  'extendedIngredients': 'ingredients',
+  'diets': 'intolerances',
+  'analyzedInstructions': 'steps',
+  'cuisines': 'cuisines',
+  'pricePerServing': 'pricePerServing',
+  'readyInMinutes': 'readyInMinutes',
+  'servings': 'servings',
+  'vegan': 'vegan',
+  'vegetarian': 'vegetarian'
+};

--- a/source/assets/scripts/recipe-data.js
+++ b/source/assets/scripts/recipe-data.js
@@ -16,10 +16,11 @@ export const recipe_data = {
   'readyInMinutes': 0,
   'servings': 0,
   'vegan': true,
-  'vegetarian': true
-}
+  'vegetarian': true,
+  'difficulty': 0  // currently configured as ingredients.length*steps.length/readyInMinutes
+};
 
-// fields we want to keep from the raw json response of Spoonacular and what they remap to
+// fields we want to keep from the raw json response of Spoonacular and what they map to. Ex. 'id' was 'hash'
 /** @global */
 export const keep_fields = {
   'id': 'hash',

--- a/source/assets/scripts/recipe-detail.js
+++ b/source/assets/scripts/recipe-detail.js
@@ -36,7 +36,7 @@ function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -44,20 +44,20 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-add.html");
+    window.location.replace('recipe-add.html');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }

--- a/source/assets/scripts/recipe-searchPage.js
+++ b/source/assets/scripts/recipe-searchPage.js
@@ -31,7 +31,7 @@ function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -39,20 +39,20 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-add.html");
+    window.location.replace('recipe-add.html');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }

--- a/source/assets/scripts/setting.js
+++ b/source/assets/scripts/setting.js
@@ -15,7 +15,7 @@ function goPreferenceSetting() {
   const prefClass = document.getElementsByClassName('preference')[0];
   const imgBtn = prefClass.getElementsByTagName('p')[1];
   imgBtn.addEventListener('click', () => {
-    window.location.replace("preference-setting.html");
+    window.location.replace('preference-setting.html');
   });
 }
 
@@ -24,7 +24,7 @@ function goDashboard() {
   const btn = document.getElementsByClassName('nav-dashboard');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("index.html");
+    window.location.replace('index.html');
   });
 }
 
@@ -32,20 +32,20 @@ function goSearch() {
   const btn = document.getElementsByClassName('nav-search');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-searchPage.html");
+    window.location.replace('recipe-searchPage.html');
   });
 }
 function goAdd() {
   const btn = document.getElementsByClassName('nav-add');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("recipe-add.html");
+    window.location.replace('recipe-add.html');
   });
 }
 function goSettings() {
   const btn = document.getElementsByClassName('nav-settings');
 
   btn[0].addEventListener('click', () => {
-    window.location.replace("settings.html");
+    window.location.replace('settings.html');
   });
 }

--- a/source/index.html
+++ b/source/index.html
@@ -12,9 +12,9 @@
   <link href="assets/styles/index.css" rel="stylesheet" <title>Dashboard</title>
 
   <!-- Web Components -->
-  <script src="assets/components/RecipeCard.js" type="module"></script>
-
-  <script src="assets/scripts/index.js"></script>
+  <script type="module" src="assets/components/RecipeCard.js"></script>
+  <script type="module" src="assets/scripts/index.js"></script>
+  <script type="module" src="assets/scripts/api.js"></script>
 </head>
 
 <body>

--- a/source/index.html
+++ b/source/index.html
@@ -14,7 +14,6 @@
   <!-- Web Components -->
   <script type="module" src="assets/components/RecipeCard.js"></script>
   <script type="module" src="assets/scripts/index.js"></script>
-  <script type="module" src="assets/scripts/api.js"></script>
 </head>
 
 <body>

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -1,0 +1,51 @@
+/**
+ * testing the functionalities of the api module
+ */
+
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+  clear() {
+    this.store = {};
+  }
+  getItem(key) {
+    return this.store[key] || null;
+  }
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+  removeItem(key) {
+    delete this.store[key];
+  }
+}
+global.localStorage = new LocalStorageMock;  // we need this to mock the local storage
+import fetch from 'node-fetch';  // we need a fetch equivalent for nodejs
+global.fetch = fetch;
+
+// test begins
+import { search_recipe } from '../../source/assets/scripts/api.js';
+import { recipe_data } from '../../source/assets/scripts/recipe-data.js'
+
+test('testing search recipe w/o intolerance', async () => {
+  const result = await search_recipe('cherry pie');
+  result.forEach(recipe => Object.keys(recipe_data).forEach(key => {
+    expect(recipe).toHaveProperty(key);  // check every key exists
+    expect(typeof recipe[key]).toBe(typeof recipe_data[key]);  // check every value has the right type
+  }));
+});
+
+test('testing search recipe w/ intolerance', async () => {
+  const result = await search_recipe('cherry pie', ['gluten']);  // should have just 1 entry haha
+  result.forEach(recipe => Object.keys(recipe_data).forEach(key => {
+    expect(recipe).toHaveProperty(key);  // check every key exists
+    expect(typeof recipe[key]).toBe(typeof recipe_data[key]);  // check every value has the right type
+    expect(recipe.intolerances.join(',')).toContain('gluten');  // intolerances should have gluten
+  }));
+});
+
+test('testing search recipe that should return emtpy list', async () => {
+  const result = await search_recipe('computer');  // should have just 0 entry
+  expect(result).toHaveLength(0);
+});
+ 


### PR DESCRIPTION
### Features Added/Issues Addressed
1. Reformatted code so linter doesn't scream and CI isn't broken
2. Addressed #56 by added `recipe_data` as our recipe data serialization template
3. Fixed intolerances bug and improved `get_recipe()` function
4. Added documentation
5. Added tests

### Brief Description of Solution
Fixed linter by adding a new rule that sends unused variables to warnings instead of errors. Additionally, ran `npm run lint` to fix spacing and semicolon issues.

Improved `get_recipe()` by
* separating out the fetch raw json and filtering into different functions
* combined intolerance search with regular search
* returns empty lists instead of undefined when recipe not found
* the recipe returned will follow the `recipe_data` object. So in the future we can easily add more fields by changing `recipe_data`

### Checklist
- [x] Added new tests (You know the code best to make new tests)
- [x] Resolved merge conflicts (Prefer merge over rebase)
- [x] Status check passed (Linted and tested)
- [ ] Reviewed (At least one reviewer's approval)

### Caveat/Special Instructions for Team
@prorick @sora1998 @meshachadoe @yiw008 and anyone else working on recipe cards,
please take a look at [this file](https://github.com/cse110-fa21-group30/cse110-fa21-group30/blob/aed2f788df799e4c8df5337616bbb978260d88b2/source/assets/scripts/recipe-data.js).
Feel free to comment below if that is a good enough format for what we do

I also upgraded our spoonacular subscription to the basic tier (150/day + $0.007 per request over 150). If we use considerably more (300+ requests per day), please let me know and I can upgrade it again : )
