### PR TITLE
Change the expand recipecard to correctly show the custom recipe level

### DIFF
--- a/source/assets/components/ExpandedRecipeCard.js
+++ b/source/assets/components/ExpandedRecipeCard.js
@@ -138,18 +138,25 @@ class RecipeCard extends HTMLElement {
     });
 
     const level = document.createElement('span');
-    const setLevel = data.difficulty;
-    let numLevel;
 
-    if (setLevel > 0.75) 
-      numLevel = 4;
-    else if (setLevel > 0.50) 
-      numLevel = 3;
-    else if (setLevel > 0.25) 
-      numLevel = 2;
-    else 
-      numLevel = 1;
-    level.textContent = numLevel;
+    let numLevel;
+    if(data.difficulty_realLevel == null){
+        const setLevel = data.difficulty;
+        if (setLevel > 0.75) 
+            numLevel = 4;
+        else if (setLevel > 0.50) 
+            numLevel = 3;
+        else if (setLevel > 0.25) 
+            numLevel = 2;
+        else 
+            numLevel = 1;
+        level.textContent = numLevel;
+    }
+    else{
+        numLevel = data.difficulty_realLevel;
+        level.textContent = numLevel;
+    }
+    
     level.classList.add('level');
     level.classList.add(`level-${numLevel}`);
 


### PR DESCRIPTION
### Features Added/Issues Addressed
1. Change the expand recipecard to correctly show the custom recipe level

### Brief Description of Solution
_e.g. Moved divider up and ..._

### Checklist
- [ ] Added new tests (You know the code best to make new tests)
- [ ] Resolved merge conflicts (Prefer merge over rebase)
- [ ] Status check passed (Linted and tested)
- [ ] Reviewed (At least one reviewer's approval)

### Caveat/Special Instructions for Team
_ex. need to run `abc` to install `xyz` ..._
